### PR TITLE
v-1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ node replacer.js fixCommit config.json
 ### Описание
 
 Описание файла конфигурации для переименовывания контролов:
+Если модуль полностью переносится, то можно использовать сокращенную запись для module и controls[i].newModuleName, указав /\* в конце. Например Name переносится в Controls-Name, тогда module: "Name/\*", а controls[i].newModuleName: "Controls-Name/\*"
 
 ```json
 {
@@ -155,6 +156,43 @@ str.replace(new RegExp(congig.reg, config.flag || "g"), config.replace);
 }
 ```
 
+Перенос всего модуля из одного места в другое. Например: `Name/*` в `Controls-Name/*`
+
+```json
+{
+  "path": "",
+  "replaces": [
+    {
+      "module": "Name/*",
+      "controls": [
+        {
+          "name": "",
+          "newModuleName": "Controls-Name/*"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Перенос отдельных частей модуля из одного места в другое. Например: `Name/Input` в `Controls-Name/Input`
+
+````json
+{
+  "path": "",
+  "replaces": [
+    {
+      "module": "Name/Input",
+      "controls": [
+        {
+          "name": "*",
+          "newModuleName": "Controls-Name/Input"
+        }
+      ]
+    }
+  ]
+}
+
 Замена `Controls/buttons:ArrowButton` на `Controls/extButtons:ArrowButton`
 
 ```json
@@ -172,7 +210,7 @@ str.replace(new RegExp(congig.reg, config.flag || "g"), config.replace);
     }
   ]
 }
-```
+````
 
 Замена `Controls/toggle:Tumbler` на `Controls/toggle:NewTumbler`
 
@@ -326,6 +364,8 @@ import * as toggle from "Controls/toggle";
 Также если контрол использовался так `Controls.LoadingIndicator`, а нужно превратить его в `Controls.loading:Indicator`,
 то скрипт самостоятельно не сможет подобное обработать, а любая попытка провернуть подобное может обернуться ошибками.
 Возможно, когда-то подобный функционал появится, но на данный момент в нем нет необходимости.
+
+При переносе модуля, когда используется конструкции с указанием в имени модуля "/\*", и указанием нового имени контрола, произойдет переименовывание самого модуля, старое имя контрола при этом не заменится.
 
 ## Что не корректно работает с переименовыванием опций
 

--- a/dist/replacer.js
+++ b/dist/replacer.js
@@ -340,8 +340,13 @@ class Replacer {
     }
     importReplacer(str, config) {
         const { controlName, newControlName, moduleName } = config;
-        if (controlName === '*') {
+        if (controlName === "*") {
             return str.replace(new RegExp("(\"|')" + moduleName + "(\"|')", "g"), "'" + config.newModuleName + "'");
+        }
+        if (moduleName[moduleName.length - 1] === "*") {
+            const correctModuleName = moduleName.replace("/*", "");
+            const correctNewModuleName = config.newModuleName.replace("/*", "");
+            return str.replace(new RegExp("(\"|')" + correctModuleName, "g"), "$1" + correctNewModuleName);
         }
         const importsReplacer = this.importParse(str, controlName, moduleName);
         if (importsReplacer) {
@@ -366,7 +371,7 @@ class Replacer {
                         }
                         else {
                             const replaceReg = new RegExp("\\b" + importReplacer.control + "\\b");
-                            const rValue = importReplacer.name === importReplacer.control ? `default as ${controlName}` : 'default';
+                            const rValue = importReplacer.name === importReplacer.control ? `default as ${controlName}` : "default";
                             const updateImportReplacer = this.importParse(value, importReplacer.control, config.newModuleName);
                             if (updateImportReplacer && updateImportReplacer.length) {
                                 const replaceValue = updateImportReplacer[0].fullImport.replace(replaceReg, rValue);
@@ -422,16 +427,23 @@ class Replacer {
             newPath.pop();
         }
         SEPARATORS.forEach((separator) => {
-            if (newName === '*') {
-                if (separator.control === ':') {
+            if (newName === "*") {
+                if (separator.control === ":") {
                     return;
                 }
             }
-            const replace = (newName === '*' ? '(<|\"|\'|/|!)' : '')
-                + path.join(separator.lib)
-                + ((controlName === '*') ? '' : (separator.control + controlName));
-            const replacer = newName === '*' ? "$1" + newPath.join(separator.lib) : newPath.join(separator.lib) + (newControlName ? separator.control : separator.lib) + newName;
-            value = value.replace(new RegExp(replace, "g"), replacer);
+            if (newName === "*" || moduleName[moduleName.length - 1] === "*") {
+                const correctPath = moduleName.replace("/*", "").split("/");
+                const correctNewPath = newModuleName.replace("/*", "").split("/");
+                const replace = "(<|\"|'|/|!)" + correctPath.join(separator.lib);
+                const replacer = "$1" + correctNewPath.join(separator.lib);
+                value = value.replace(new RegExp(replace, "g"), replacer);
+            }
+            else {
+                const replace = path.join(separator.lib) + separator.control + controlName;
+                const replacer = newPath.join(separator.lib) + (newControlName ? separator.control : separator.lib) + newName;
+                value = value.replace(new RegExp(replace, "g"), replacer);
+            }
         });
         return value;
     }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   "files": [
     "dist"
   ],
-  "version": "1.3.1"
+  "version": "1.5.0"
 }


### PR DESCRIPTION
https://github.com/max36895/control-replacer/issues/8 
Добавлена возможность более просто настроить конфиг для переноса модулей. Теперь не нужно указывать все элементы модуля